### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/notify/notify.js
+++ b/notify/notify.js
@@ -6,7 +6,7 @@ const eventPayload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, '
 
 const message = {
 	body: process.env.MESSAGE || 'No message specified',
-	title: `Github Notification from ${eventPayload.repository.full_name}`
+	title: `GitHub Notification from ${eventPayload.repository.full_name}`
 }
 
 if (!process.env.API_KEY) {


### PR DESCRIPTION
Sorry, just my OCD coming into play. :joy:
___
All this commit changes is the capitalization of GitHub in the notification title.