### PR TITLE
Update notify.js, use ENV instead of event for repo

### DIFF
--- a/notify/notify.js
+++ b/notify/notify.js
@@ -6,7 +6,7 @@ const eventPayload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, '
 
 const message = {
 	body: process.env.MESSAGE || 'No message specified',
-	title: `GitHub Notification from ${eventPayload.repository.full_name}`
+	title: `GitHub Notification from ${process.env.GITHUB_REPOSITORY}`
 }
 
 if (!process.env.API_KEY) {


### PR DESCRIPTION
The event payload doesn't appear to be present for the `schedule` trigger, but this should cover any situation in actions?